### PR TITLE
Adding a ssh step to before_install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ before_install:
     - chmod 0600 .travis.key
     - ssh-add .travis.key
     - ssh-add -L
+    - ssh hdmi2usb@build.hdmi2usb.tv /bin/true
 
 install:
     - true


### PR DESCRIPTION
This means if SSH fails for any reason it will be a "Build Error" rather than
a "Test failure" message.
