### PR TITLE
Fixing #81 - Force Makefile to use bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+
+# We use the special PIPESTATUS which is bash only below.
+SHELL := /bin/bash
+
 COLORMAKETOOL = "../tools/colormake.pl"
 
 INTSTYLE = ise


### PR DESCRIPTION
We used PIPESTATUS which is bash only.
