### PR TITLE
Suppress severe warnings

### DIFF
--- a/hdl/UART/Baud_generator.v
+++ b/hdl/UART/Baud_generator.v
@@ -50,7 +50,8 @@ module counter
          x <= x_n;
 
   
-   assign x_n = (x==(M-1)) ? 0 : x + 1;
+
+   assign x_n = (x==(M-1)) ? 1'b0 : x + 1'b1;
    
    assign q = x;
    assign max_tck = (x==(M-1)) ? 1'b1 : 1'b0;

--- a/hdl/UART/FIFO.v
+++ b/hdl/UART/FIFO.v
@@ -75,8 +75,8 @@ module fifo#(parameter B=8, // number of bits in a word
    always @*
    begin
      
-      w_ptr_succ = w_ptr_reg + 1;
-      r_ptr_succ = r_ptr_reg + 1;
+      w_ptr_succ = w_ptr_reg + 1'b1;
+      r_ptr_succ = r_ptr_reg + 1'b1;
       
       w_ptr_next = w_ptr_reg;
       r_ptr_next = r_ptr_reg;

--- a/hdl/UART/RX_module.v
+++ b/hdl/UART/RX_module.v
@@ -92,7 +92,7 @@ module uart_rx
                      n_next = 0;
                   end
                else
-                  s_next = s + 1;
+                  s_next = s + 1'b1;
          end
       else if(state==data)
          begin
@@ -104,10 +104,10 @@ module uart_rx
                      if (n==(DBIT-1))
                         state_next = stop ;
                       else
-                        n_next = n + 1;
+                        n_next = n + 1'b1;
                    end
                else
-                  s_next = s + 1;
+                  s_next = s + 1'b1;
          end
        else if(state==stop)
          begin
@@ -118,7 +118,7 @@ module uart_rx
                      rx_done_tck =1'b1;
                   end
                else
-                  s_next = s + 1;
+                  s_next = s + 1'b1;
          end
    end
    

--- a/hdl/UART/TX_module.v
+++ b/hdl/UART/TX_module.v
@@ -99,7 +99,7 @@ module uart_tx
                         n_next = 0;
                      end
                   else
-                     s_next = s + 1;
+                     s_next = s + 1'b1;
             end
          else if(state==data)
             begin
@@ -112,10 +112,10 @@ module uart_tx
                         if (n==(DBIT-1))
                            state_next = stop ;
                         else
-                           n_next = n + 1;
+                           n_next = n + 1'b1;
                      end
                   else
-                     s_next = s + 1;
+                     s_next = s + 1'b1;
             end
          else if(state==stop)
             begin
@@ -127,7 +127,7 @@ module uart_tx
                         tx_done_tck = 1'b1;
                      end
                   else
-                     s_next = s + 1;
+                     s_next = s + 1'b1;
             end
    end
 

--- a/hdl/edid/edid_master_slave_hack.v
+++ b/hdl/edid/edid_master_slave_hack.v
@@ -118,7 +118,7 @@ always @(posedge clk) begin
 						stop <= 1;
 						hpd_pc <=1;
 					end else begin
-						segment_count <= segment_count+1;
+						segment_count <= segment_count+ 1'b1;
 					end					
 				end
 				if (counter == 0) begin

--- a/hdl/edid/edidmaster.v
+++ b/hdl/edid/edidmaster.v
@@ -91,12 +91,13 @@ always @(posedge clk) begin
 		out_en <=0;
 	end else begin // clk 
 	
-	out_en <=0;
-	scl_counter <= scl_counter +1;
+	out_en <= 0;
 	
 	if (scl_counter == 499) begin
 		scl <= ~ scl;
 		scl_counter <= 0;
+        end else begin
+		scl_counter <= scl_counter + 1'b1;
 	end
 	
 	scl_q <= scl;
@@ -132,7 +133,7 @@ always @(posedge clk) begin
 
 			WRITE_BYTE_ADD_W: begin//3
 				if (scl_fallingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdaout <= address_w[bitcount];
 					if (bitcount==0) begin
 						state <= FREE_SDA_ADD_W;
@@ -160,7 +161,7 @@ always @(posedge clk) begin
 
 			WRITE_BYTE_REG: begin//6
 				if (scl_fallingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdaout <= reg0[bitcount];
 					if (bitcount==0) begin
 						state <= FREE_SDA_REG;
@@ -202,7 +203,7 @@ always @(posedge clk) begin
 
 			WRITE_BYTE_ADD_R: begin//9
 				if (scl_fallingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdaout <= address_r[bitcount];
 					if (bitcount==0) begin
 						state <= FREE_SDA_ADD_R;
@@ -230,7 +231,7 @@ always @(posedge clk) begin
 	
 			READ_DATA: begin //12
 				if (scl_risingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdadata[bitcount] <= sdain;
 					if (bitcount==0) begin
 						out_en <= 1;

--- a/hdl/edid/edidslave.v
+++ b/hdl/edid/edidslave.v
@@ -148,7 +148,7 @@ always @(posedge clk) begin
 			
 			READ_ADDRESS: begin //2
 				if (scl_risingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdadata[bitcount] <= sdain;
 					if (bitcount==0) begin
 						state <= SEND_ADDRESS_ACK;
@@ -172,7 +172,7 @@ always @(posedge clk) begin
 			
 			READ_REGISTER_ADDRESS: begin//4
 				if (scl_risingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdadata[bitcount] <= sdain;
 					if (bitcount==0) begin
 						state <= SEND_REGISTER_ADDRESS_ACK;
@@ -202,7 +202,7 @@ always @(posedge clk) begin
 			
 			READ_ADDRESS_AGAIN: begin//7
 				if (scl_risingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					sdadata[bitcount] <= sdain;
 					if (bitcount==0) begin
 						state <= SEND_ADDRESS_ACK_AGAIN;
@@ -219,7 +219,7 @@ always @(posedge clk) begin
 						
 			WRITE_BYTE: begin//9
 				if (scl_fallingedge) begin
-					bitcount <= bitcount -1;
+					bitcount <= bitcount - 1'b1;
 					if (dvi_only) begin
 						sdaout <= data[bitcount];
 					end else begin
@@ -227,7 +227,7 @@ always @(posedge clk) begin
 					end
 					if (bitcount==0) begin
 						state <= FREE_SDA;
-						adr <= adr +1;
+						adr <= adr + 1'b1;
 						if ((adr ==  127) & dvi_only) begin
 							state <= INI;
 						end else if (adr == 255) begin

--- a/hdl/misc/calc_res.v
+++ b/hdl/misc/calc_res.v
@@ -64,7 +64,7 @@ end else begin
 	de_q <= de;
 
 	if (de) begin
-		resX_q <= resX_q +1;
+		resX_q <= resX_q + 1'b1;
 	end else if (hsync_risingedge) begin
 		resX_q <= 0;
 		if (resX_q != 0) begin
@@ -73,7 +73,7 @@ end else begin
 	end
 	
 	if (de_risingedge) begin
-		resY_q <= resY_q + 1;
+		resY_q <= resY_q + 1'b1;
 	end else if (de_fallingedge) begin
 		resY_t <= resY_q;
 	end else if (vsync_risingedge) begin


### PR DESCRIPTION
These warnings are reported as severe by ISE 14.7, however none of them appear to be real issues - in all cases the HDL compiler is assuming that adding `1` to a signal will cause it to overflow. This may or not be true. For some reason, the compiler can be silenced by instead adding `1b1`, ie a signal 1  that is of length 1.

I have checked that there is no real error being reported by the warnings, so I believe it is safe to suppress them.
